### PR TITLE
http client를 base directory로 이동

### DIFF
--- a/src/base/apis/http-client.ts
+++ b/src/base/apis/http-client.ts
@@ -1,0 +1,31 @@
+import ky from "ky";
+import { redirect } from "next/navigation";
+import type { KyInstance, Options, KyResponse, KyRequest } from "ky";
+import { cookies } from "next/headers";
+
+const client: KyInstance = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_API_URL,
+  credentials: "include",
+  hooks: {
+    beforeRequest: [
+      async (request: Request) => {
+        const cookieStore = cookies();
+        const accessToken = await cookieStore.get("accessToken")?.value;
+        if (accessToken) {
+          request.headers.set("Authorization", `Bearer ${accessToken}`);
+        }
+      },
+    ],
+    afterResponse: [
+      async (request: KyRequest, options: Options, response: KyResponse) => {
+        if (response.status === 401) {
+          const clientRoute = request.headers.get("X-Client-Route") || "/";
+          redirect(`/api/auth/refresh?next=${encodeURIComponent(clientRoute)}`);
+        }
+        return response;
+      },
+    ],
+  },
+});
+
+export default client;


### PR DESCRIPTION
## Summary

HTTP 클라이언트를 base 디렉토리로 이동하여 코드 구조를 개선했습니다. 이 변경은 HTTP 클라이언트를 애플리케이션 전체에서 더 쉽게 접근할 수 있도록 하고, 코드 구조를 더 명확하게 만들게 만들었습니다.

## PR 유형 및 세부 작업 내용

- [x] 코드 리팩토링
- [x] 파일 혹은 폴더 수정

### 세부 내용

- HTTP 클라이언트를 `src/base/apis/http-client.ts` 위치로 이동
