### PR TITLE
추가된 daily api endpoint 구현

### DIFF
--- a/src/daily/apis/index.ts
+++ b/src/daily/apis/index.ts
@@ -4,6 +4,8 @@ import type {
   TagAddRequest,
   AddTagResponse,
   TagRemoveRequest,
+  DailyDetailResponse,
+  FeedDailyResponses,
 } from "./types";
 
 /**
@@ -25,10 +27,19 @@ export async function uploadDaily(file: File): Promise<DailyUploadResponse> {
 /**
  * Get a specific daily content by ID
  * @param dailyId - The ID of the daily to retrieve
- * @returns Promise with the daily content as a Blob
+ * @returns Promise with the daily details including tags and user information
  */
-export async function getDaily(dailyId: number): Promise<Blob> {
-  return await client.get(`daily/${dailyId}`).blob();
+export async function getDaily(dailyId: number): Promise<DailyDetailResponse> {
+  return await client.get(`daily/${dailyId}`).json<DailyDetailResponse>();
+}
+
+/**
+ * Get a daily image by ID
+ * @param dailyId - The ID of the daily to retrieve the image for
+ * @returns Promise with the image data as a Blob
+ */
+export async function getDailyImage(dailyId: number): Promise<Blob> {
+  return await client.get(`daily/${dailyId}/image`).blob();
 }
 
 /**
@@ -65,4 +76,23 @@ export async function removeTagFromDaily(
   await client.delete(`daily/${dailyId}/tag`, {
     json: data,
   });
+}
+
+interface GetAllDailiesParams {
+  page: number;
+  size: number;
+}
+
+/**
+ * Get all dailies with pagination
+ * @param params - Pagination parameters (page number and size)
+ * @returns Promise with paginated daily feed responses
+ */
+export async function getAllDailies({
+  page,
+  size,
+}: GetAllDailiesParams): Promise<FeedDailyResponses> {
+  return await client
+    .get(`daily/all?page=${page}&size=${size}`)
+    .json<FeedDailyResponses>();
 }

--- a/src/daily/apis/types.ts
+++ b/src/daily/apis/types.ts
@@ -11,6 +11,11 @@ export interface AddTagResponse {
   tagName: string;
 }
 
+export interface TagDetailResponse {
+  tagId: number;
+  tagName: string;
+}
+
 export interface TagRemoveRequest {
   tagId: number;
 }
@@ -27,4 +32,23 @@ export interface FieldError {
   field: string;
   value?: unknown;
   reason: string;
+}
+
+export interface DailyDetailResponse {
+  dailyId: number;
+  userId: number;
+  userNickname: string;
+  tags: TagDetailResponse[];
+}
+
+export interface FeedDailyResponse {
+  dailyId: number;
+  userId: number;
+  userNickname: string;
+}
+
+export interface FeedDailyResponses {
+  currentPage: number;
+  isEnd: boolean;
+  dailies: FeedDailyResponse[];
 }


### PR DESCRIPTION
## Summary

Daily API 관련 타입 정의와 엔드포인트를 추가했습니다. Swagger 문서를 기반으로 누락된 API들을 구현했습니다.

## PR 유형 및 세부 작업 내용

- [x] 새로운 기능 추가

### 세부 내용

1. Daily API 응답 타입 추가

   - `TagDetailResponse`
   - `DailyDetailResponse`
   - `FeedDailyResponse`
   - `FeedDailyResponses` (페이지네이션)

2. Daily API 엔드포인트 구현
   - `getDaily` 응답 타입 수정 (Blob → DailyDetailResponse)
   - `getDailyImage` 엔드포인트 추가
   - `getAllDailies` 페이지네이션 엔드포인트 추가

## 테스트 완료 여부

- [ ] 각 API 엔드포인트 호출 테스트 필요
- [ ] 응답 타입 일치 여부 확인 필요

## 리뷰 요구사항

- Daily API 응답 타입이 Swagger 문서와 일치하는지 확인 부탁드립니다.
- 페이지네이션 파라미터 처리 방식이 적절한지 검토 부탁드립니다.
