### PR TITLE
외부 도메인 이미지 로드되지 않는 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 
 # cursor
 .cursor
+
+# wrangler
+.wrangler

--- a/imageLoader.ts
+++ b/imageLoader.ts
@@ -11,6 +11,11 @@ export default function cloudflareLoader({
   width: number;
   quality?: number;
 }) {
+  // If it's an external URL (starts with http or https), return it directly
+  if (src.startsWith("http://") || src.startsWith("https://")) {
+    return src;
+  }
+
   if (process.env.NODE_ENV === "development") {
     return src;
   }

--- a/imageLoader.ts
+++ b/imageLoader.ts
@@ -12,6 +12,7 @@ export default function cloudflareLoader({
   quality?: number;
 }) {
   // If it's an external URL (starts with http or https), return it directly
+  // TODO optimize external images
   if (src.startsWith("http://") || src.startsWith("https://")) {
     return src;
   }


### PR DESCRIPTION
## Summary

Cloudflare 환경에서 외부 도메인(Google) 프로필 이미지가 로드되지 않는 문제를 수정했습니다.
외부 이미지 URL이 Cloudflare의 이미지 최적화 시스템과 호환되지 않아 404 오류가 발생하던 문제를 해결했습니다.

## PR 유형 및 세부 작업 내용

- [x] 버그 수정

### 세부 내용

- `imageLoader.ts` 파일을 수정하여 외부 URL(http:// 또는 https://로 시작하는)을 감지하도록 했습니다.
- 외부 URL의 경우 Cloudflare의 이미지 최적화를 우회하고 원본 URL을 그대로 반환하도록 했습니다.
- 이를 통해 Google 프로필 이미지와 같은 외부 이미지가 정상적으로 표시됩니다.
- 내부 이미지(도메인 내 이미지)는 여전히 Cloudflare의 이미지 최적화 혜택을 받습니다.

## 문제 원인

이전 코드에서는 모든 이미지에 대해 `/cdn-cgi/image/width=xxx/[image-url]` 형식의 Cloudflare 이미지 최적화 URL을 생성했는데,
이 방식은 외부 URL에 대해 작동하지 않아 다음과 같은 404 오류가 발생했습니다:

```
GET https://matchreal.pages.dev/cdn-cgi/image/width=256/https://lh3.googleusercontent.com/a/ACg8ocKv_VS17uwuVIXAP8UnFitVzSDhZdecp-wj5ChmOuiiOx--qJU=s96-c 404 (Not Found)
```

## 해결 방법

외부 URL을 감지하여 Cloudflare 이미지 최적화를 우회하도록 처리했습니다:

```typescript
// If it's an external URL (starts with http or https), return it directly
if (src.startsWith("http://") || src.startsWith("https://")) {
  return src;
}
```

## 테스트 완료 여부

- [x] 로컬 개발 환경에서 테스트 완료
- [x] Cloudflare Pages 배포 환경에서 테스트 완료

## 작동 스크린샷

